### PR TITLE
Fix issue with destroying a region plugin instance

### DIFF
--- a/src/plugin/regions/index.js
+++ b/src/plugin/regions/index.js
@@ -123,6 +123,8 @@ export default class RegionsPlugin {
         observerPrototypeKeys.forEach(key => {
             Region.prototype[key] = this.util.Observer.prototype[key];
         });
+        this._disabledEventEmissions = [];
+        this.handlers = [];
         this.wavesurfer.Region = Region;
 
         this._onBackendCreated = () => {


### PR DESCRIPTION
Include the _disabledEventEmissions and handlers member variables during construction.

I noticed when I destroyed a wavesurfer instance with the regions plugin active, it would fail with an undefined error on accessing _disabledEventEmissions. I added those properties in the constructor, not sure if that's the correct fix, though.